### PR TITLE
fix(docs): adjust embedded md image indentation

### DIFF
--- a/docs/en/opening-repository-in-GH-codespaces.md
+++ b/docs/en/opening-repository-in-GH-codespaces.md
@@ -39,7 +39,7 @@ Choose the workflow that best fits your setup. If you're working locally in your
     5. Wait for the Codespace to finish provisioning in the browser.
     6. Once the Codespace is ready, you'll see a VS Code experience in the browser. You can continue there or click **Open in VS Code** to connect from your desktop.
     
-        ![Open in VS Code button](./media/open-in-vscode.png)
+![Open in VS Code button](./media/open-in-vscode.png)
 
 !!! success
     To revisit the workshop later, click your profile picture on GitHub and select **Your stars**.


### PR DESCRIPTION
## Summary
Fix the indentation of an embedded image in the instruction documentation so the Markdown renderer treats it as an actual image (instead of a mis-indented block) and the image correctly appears in the repository docs.

## What changed
- Adjusted the leading whitespace/indentation for the embedded Markdown image in the instruction docs.
- Ensured the image syntax (`![alt](path)`) is aligned with surrounding Markdown so it renders as an image in GitHub.

## Why
The image was indented in a way that caused GitHub-flavored Markdown to interpret it as part of a block (e.g., code block / nested list / quote), preventing the image from rendering in the docs page. This change makes the docs display correctly.

## Verification
- Viewed the updated documentation in the GitHub PR preview / repository view.
- Confirmed the embedded image renders inline at the intended location.

## Notes
No functional code changes; documentation-only formatting fix.