### PR TITLE
Fix heading formatting in workshop introduction

### DIFF
--- a/docs/en/workshop-introduction.md
+++ b/docs/en/workshop-introduction.md
@@ -1,6 +1,6 @@
 # Workshop Introduction
 
-## Migrating Zava's Temperature API from Python to C #
+## Migrating Zava's Temperature API from Python to C#
 
 Zava recently acquired an external company whose apps and services were implemented primarily in Python. Many of those services include temperature, season and location endpoints that are useful for Zava's product line. Since Zava's main backend and operational tooling are built on C#, the engineering leadership started a deliberate migration process to bring the acquired Python services into the C#/.NET ecosystem.
 


### PR DESCRIPTION
C# was not previously rendering due a typing error.

This pr takes the title from this:

<img width="831" height="259" alt="Screenshot 2026-02-19 at 12 07 36" src="https://github.com/user-attachments/assets/65589015-dd5f-4348-8763-1b91ea8fd3df" />

to this:
<img width="847" height="252" alt="Screenshot 2026-02-19 at 12 06 14" src="https://github.com/user-attachments/assets/a223a81f-bd1d-40fa-b2a9-07f67d24138b" />
