### PR TITLE
fix: uvicorn start app easy

### DIFF
--- a/src/python-app/webapp/main.py
+++ b/src/python-app/webapp/main.py
@@ -31,3 +31,7 @@ def countries():
 @app.get('/countries/{country}/{city}/{month}')
 def monthly_average(country: str, city: str, month: str):
     return data[country][city][month]
+
+if __name__ == "__main__":
+    import uvicorn 
+    uvicorn.run(app, host = '0.0.0.0', port = 8000)


### PR DESCRIPTION
Make the python main.py start the FASTAPI server easily instead of writing uvicorn:app on terminal which is a hassle...