### PR TITLE
Modified Link missing for i18n

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Real World Code Migration with GitHub Copilot
+site_url: https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode/
 site_author: Alfredo Deza, Gustavo Cordido
 site_description: Perform a challenging migration to a completely different language.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Real World Code Migration with GitHub Copilot
+site_url: https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode/
 site_author: Alfredo Deza, Gustavo Cordido
 site_description: Perform a challenging migration to a completely different language.
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the **language switcher (Japanese)** in the top navigation links to an incorrect URL in the **production GitHub Pages environment**, resulting in a `404 Not Found`.

The Japanese pages themselves are correctly generated and accessible, but the language selector was routing users to the wrong base path.

---

## Problem Description

When accessing the production site:　https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode

and selecting **“日本語 (Japanese)”** from the top menu, users were redirected to the following URL: https://microsoft.github.io/ja/

This URL does **not** include the repository path and results in a **404 Not Found**, preventing navigation to the Japanese version of the site.

---

## Expected Behavior

Selecting **“日本語 (Japanese)”** from the language switcher should navigate to: https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode/ja/

---

## Root Cause Analysis

- In the **local development environment**, selecting “日本語” worked correctly and displayed the Japanese pages.
- In the **production environment**, however, the generated link for the language switcher:
  - Dropped the repository name (`aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode`)
  - Resulted in an incorrect root-level URL: `https://microsoft.github.io/ja/`

Additional verification showed that:
- The Japanese pages are correctly generated and deployed
- Manually accessing the following URL works as expected: https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode/ja/

This indicates the issue was **not page generation**, but **URL construction for the language switcher** in production.

---

## Fix Applied

To ensure correct URL generation in the production GitHub Pages environment, the following configuration was added:

```yaml
site_url: https://microsoft.github.io/aitour26-WRK541-real-world-code-migration-with-github-copilot-agent-mode/